### PR TITLE
Introduce caching in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,16 +49,6 @@ jobs:
       - name: Clone and setup Mbin repo
         run: git clone https://github.com/mbinOrg/mbin && cp mbin/.env.example mbin/.env
 
-      - name: Get NPM cache directory path
-        id: npm-cache-dir-path
-        run: echo "dir=$(npm get cache)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-npm-
-
       - name: Install Npm dependencies
         run: npm ci
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: ["main"]
 
+  pull_request:
+    branches:
+      - main
+
   # Runs every hour
   schedule:
     - cron: "0 * * * *"
@@ -74,7 +78,9 @@ jobs:
 
       - name: Run update/build script
         run: bash update_and_build.sh -f
+
       - name: Upload artifact
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./build
@@ -86,6 +92,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,17 +34,47 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
+          cache: "npm"
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.3"
-      - name: Clone and setup mbin repo
+
+      - name: Clone and setup Mbin repo
         run: git clone https://github.com/mbinOrg/mbin && cp mbin/.env.example mbin/.env
-      - name: Install dependencies
+
+      - name: Get NPM cache directory path
+        id: npm-cache-dir-path
+        run: echo "dir=$(npm get cache)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        id: npm-cache
+        working-directory: ./mbin
+        with:
+          path: ${{ steps.npm-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
+
+      - name: Install Npm dependencies
         run: npm ci
+
+      - name: Get composer cache directory
+        id: composer-cache
+        working-directory: ./mbin
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache vendor directory
+        uses: actions/cache@v4
+        working-directory: ./mbin
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
       - name: Run update/build script
-        run: bash update_and_build.sh -f -d mbin
+        run: bash update_and_build.sh -f
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,6 @@ jobs:
         run: echo "dir=$(npm get cache)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
-        id: npm-cache
         working-directory: ./mbin
         with:
           path: ${{ steps.npm-cache-dir-path.outputs.dir }}
@@ -65,7 +64,7 @@ jobs:
         working-directory: ./mbin
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - name: Cache vendor directory
+      - name: Cache composer cache directory
         uses: actions/cache@v4
         working-directory: ./mbin
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,6 @@ jobs:
         run: echo "dir=$(npm get cache)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
-        working-directory: ./mbin
         with:
           path: ${{ steps.npm-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -70,7 +69,6 @@ jobs:
 
       - name: Cache composer cache directory
         uses: actions/cache@v4
-        working-directory: ./mbin
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ The docs are built using [Docusaurus](https://docusaurus.io/) and [Redocusaurus]
 
 For running this site you need to have an [Mbin](https://github.com/mbinOrg/mbin) repository, where our docs are hosted. The update script takes care of copying over docs and images and generating an open-api json for generating the api docs.
 
+By default the script assumes the mbin repo is in the same directory as this repo under the directory name `mbin`. If you want to use a different repo you can specify the path to the repo with the `-d` flag.
+
 ```bash
 npm ci
-bash update_and_build.sh -d YOUR_MBIN_REPO
+./update_and_build.sh -d YOUR_MBIN_REPO
 ```
 
 The repo that is linked will by default fetch and pull changes from the main branch. If you want to use another branch you can specify that by `-b BRANCH`.

--- a/update_and_build.sh
+++ b/update_and_build.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$(dirname "$(realpath "$0")")
 # Define variables
 force_update=false
 skip_build=false
-local_dir="./mbin-repo"
+local_dir="./mbin"
 new_tag_exists=false
 latest_tag=""
 branch_name="main"
@@ -16,7 +16,7 @@ usage() {
     echo "Usage: $0 [-f] [-d LOCAL_DIR] [-b BRANCH_NAME]" 1>&2
     echo "    -f          Force update even if there are no changes" 1>&2
     echo "    -s          Skip the build (eg. when you want to execute npm start)" 1>&2
-    echo "    -d LOCAL_DIR   Specify the local directory of the repository (default: ./mbin-repo)" 1>&2
+    echo "    -d LOCAL_DIR   Specify the local directory of the repository (default: ./mbin)" 1>&2
     echo "    -b BRANCH_NAME   Specify the branch name to pull changes from (default: main)" 1>&2
     exit 1
 }


### PR DESCRIPTION
We have a cronjob running on this GitHub Action.. And every hour this action is trigger, without using any cache (think about the nature)! Let's change that 🌲 . Currently the action is taking on average 3 minutes to complete, this will reduce that to about 1 minute.

- Introducing cache for GitHub Actions
   - For NPM packages, by leveraging the existing `node-setup` action and setting the `cache` option
   - For Symfony packages, by introducing a `cache` action
- Change the default `local_dir` to just `./mbin` (which is the default clone directory anyways, when cloning the mbin repo)
- Update workflow to use NodeJS v22 (latest major release)
- ~~Execute the workflow in future PRs, but don't deploy~~ -> I added this now to the main branch, so I can actually test this PR now!